### PR TITLE
Fix conquest.lua state bugs affecting nation control predicates

### DIFF
--- a/conquest.lua
+++ b/conquest.lua
@@ -203,9 +203,10 @@ local function LookupControl(zone)
     end
 end
 
+local currentZone = memory.GetCurrentZone()
 local locals = {
     CurrentNation = "Unknown",
-    CurrentZone = memory.GetCurrentZone(),
+    CurrentZone = currentZone,
     CurrentControl = LookupControl(currentZone)
 }
 
@@ -240,7 +241,7 @@ memory.RegisterPacketIn("LAC_Conquest_Module_HandleIncomingPacket", function (e)
 end)
 
 conquest.GetCurrentControl = function()
-    return locals.CrrentControl
+    return locals.CurrentControl
 end
 
 conquest.GetCurrentNation = function()
@@ -252,6 +253,9 @@ conquest.GetZoneControl = function(zone)
 end
 
 conquest.GetInsideControl = function()
+    if (locals.CurrentControl == "Unknown") then
+        return false
+    end
     return (locals.CurrentControl == locals.CurrentNation)
 end
 


### PR DESCRIPTION
- GetCurrentControl returned locals.CrrentControl (typo), so it always returned nil.
- The initial CurrentControl lookup used the undefined global currentZone; capture memory.GetCurrentZone() once and use it for both CurrentZone and the control lookup, so loading mid-session reports the real zone control.
- GetInsideControl now returns false while control is Unknown (conquest packet 0x5E / nation packet 0x61 not yet received), matching the guard in GetOutsideControl and preventing a false positive when control and nation are both Unknown.